### PR TITLE
bump: docker base image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,8 @@
 version: 2.1
 
 orbs:
-  codacy: codacy/base@6.1.1
-  codacy_plugins_test: codacy/plugins-test@0.15.4
+  codacy: codacy/base@9.3.6
+  codacy_plugins_test: codacy/plugins-test@1.1.1
 
 workflows:
   version: 2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.14.2
+FROM alpine:3.17.0
 
 WORKDIR /workdir
 


### PR DESCRIPTION
Bump base docker image to fix vulnerabilities. Also bump orbs to fix ci/cd pipelines
